### PR TITLE
Add FuseSoC support

### DIFF
--- a/enigmaFPGA.core
+++ b/enigmaFPGA.core
@@ -1,0 +1,43 @@
+CAPI=1
+[main]
+name = ::enigmaFPGA:0
+backend = icestorm
+simulators = icarus isim modelsim
+
+[fileset rtl]
+files =
+ enigma_top.v
+ state_machine.v
+ encode.v rotor.v
+ encodeASCII.v
+ decodeASCII.v
+ rotorEncode.v
+ reflectorEncode.v
+ plugboardEncode.v
+ checkKnockpoints.v
+ hex_to_7seg.v
+ uart_tx.v
+ uart_rx.v
+ generate.py[file_type=user]
+file_type = verilogSource
+
+[fileset rtl_tb]
+files = test.v[file_type=verilogSource]
+usage = sim
+
+[fileset contraints]
+files = Go_Board_Constraints.pcf[file_type=PCF]
+
+[icestorm]
+top_module = enigma_top
+yosys_synth_options = -abc2 -nocarry
+arachne_pnr_options = -d 1k -P vq100
+
+[simulator]
+toplevel = test
+
+[scripts]
+pre_build_scripts = gen_rotors_mem.sh
+pre_synth_scripts = gen_rotors_mem.sh
+
+[parameter rotors_init_file]

--- a/gen_rotors_mem.sh
+++ b/gen_rotors_mem.sh
@@ -1,0 +1,1 @@
+python $FILES_ROOT/generate.py > $WORK_ROOT/rotors.mem

--- a/generate.py
+++ b/generate.py
@@ -10,10 +10,10 @@ rotors.append(['F','K','Q','H','T','L','X','O','C','B','J','S','P','D','Z','R','
 
 for rotor in rotors:
     for code in rotor:
-        print format(ord(code)-65, '02x')
+        print(format(ord(code)-65, '02x'))
 
 for rotor in rotors:
 	for num in range(0, 26):
 		for i in range(0, 26):
 			if (rotor[i]==chr(num+65)):
-				print format(i, '02x')
+				print(format(i, '02x'))


### PR DESCRIPTION
Add FuseSoC support. Run with `fusesoc sim enigmaFPGA`. Default simulator is icarus. To use another simulator add --sim=<simulator> after the sim argument. Tested with icarus, modelsim and isim. To build for the blackice board, run `fusesoc build enigmaFPGA`.